### PR TITLE
lazyFormat for compositions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -86,15 +86,25 @@ implicit val AnimalsFormat: Format[Animals.Value] = scalaEnumerationFormat(Anima
 implicit val DaysFormat: Format[Day] = javaEnumerationFormat[Day](Day.MONDAY)
 ```
 
-### Recursive Values
+### Recursive or Composed Values
 
-Given a recursive type you will need to wrap the format in the `lazyFormat` method.
+Given a recursive type or you will need to wrap the format in the `lazyFormat` method.
 
 ```scala
 import jsonz._
 import jsonz.DefaultFormats._
 case class RecursiveType(rs: List[RecursiveType])
 implicit lazy val RecursiveTypeFormat: Format[RecursiveType] = lazyFormat(productFormat1("rs")(RecursiveType.apply)(RecursiveType.unapply))
+```
+
+Similarly with compositions, such as a case class having another case class as a member:
+
+```scala
+import jsonz._
+import jsonz.DefaultFormats._
+case class OuterType(child: InnerType)
+case class InnerType(message: String)
+implicit lazy val OuterTypeFormat: Format[OuterType] = lazyFormat(productFormat1("child")(OuterType.apply)(OuterType.unapply))
 ```
 
 ### Joda-Time

--- a/README.markdown
+++ b/README.markdown
@@ -108,6 +108,8 @@ implicit lazy val OuterTypeFormat: Format[OuterType] = lazyFormat(productFormat1
 implicit lazy val InnerTypeFormat: Format[InnerType] = productFormat1("message")(InnerType.apply)(InnerType.unapply)
 ```
 
+**Note**: Flipping the order of the above definitions would eliminate the need for `lazyFormat`, however if one format is in a 3rd party package `lazyFormat` would allow you to define this structure.
+
 ### Joda-Time
 
 Joda-Time is typically the first library chosen for performing date/time operations on the JVM. Jsonz offers support for reading and writing it's `org.joda.time.DateTime` class via the following imports. The formats used to try and parse are: `ISO 8601` (with and without millis), `yyyy-MM-dd`, and [RFC 1123](https://tools.ietf.org/html/rfc1123) (EEE, dd MMM yyyy HH:mm:ss 'GMT').

--- a/README.markdown
+++ b/README.markdown
@@ -105,6 +105,8 @@ import jsonz.DefaultFormats._
 case class OuterType(child: InnerType)
 case class InnerType(message: String)
 implicit lazy val OuterTypeFormat: Format[OuterType] = lazyFormat(productFormat1("child")(OuterType.apply)(OuterType.unapply))
+implicit lazy val InnerTypeFormat: Format[InnerType] = 
+productFormat1("message")(InnerType.apply)(InnerType.unapply)
 ```
 
 ### Joda-Time

--- a/README.markdown
+++ b/README.markdown
@@ -88,7 +88,7 @@ implicit val DaysFormat: Format[Day] = javaEnumerationFormat[Day](Day.MONDAY)
 
 ### Recursive or Composed Values
 
-Given a recursive type or you will need to wrap the format in the `lazyFormat` method.
+Given a recursive type you will need to wrap the format in the `lazyFormat` method.
 
 ```scala
 import jsonz._

--- a/README.markdown
+++ b/README.markdown
@@ -105,8 +105,7 @@ import jsonz.DefaultFormats._
 case class OuterType(child: InnerType)
 case class InnerType(message: String)
 implicit lazy val OuterTypeFormat: Format[OuterType] = lazyFormat(productFormat1("child")(OuterType.apply)(OuterType.unapply))
-implicit lazy val InnerTypeFormat: Format[InnerType] = 
-productFormat1("message")(InnerType.apply)(InnerType.unapply)
+implicit lazy val InnerTypeFormat: Format[InnerType] = productFormat1("message")(InnerType.apply)(InnerType.unapply)
 ```
 
 ### Joda-Time


### PR DESCRIPTION
I found that I needed to use lazyFormat for compositions as well as recursive types. This README change reflects what I found.