### PR TITLE
Upgrade scalaz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 DEPENDENCY CHANGES:
 
 - Removed dependency on scalaz-typelevel
+- Upgraded scalaz to 7.2
 
 # 1.4.0 (2016-08-16)
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,11 @@ releaseCrossBuild := true
 credentials += Credentials(Path.userHome / ".ivy2" / ".banno_credentials")
 
 val jacksonVersion = "2.6.7"
-val scalazVersion = "7.1.0"
+val scalazVersion = "7.2.5"
 val akkaVersion = "2.3.15"
+
+val scalaCheckVersion = "1.13.2"
+val specs2Version = "3.8.4"
 
 // required deps
 libraryDependencies ++= Seq(
@@ -63,11 +66,11 @@ libraryDependencies ++= {
 }
 
 // specs2 support
-libraryDependencies += "org.specs2" %% "specs2" % "2.4.2" % "provided"
+libraryDependencies += "org.specs2" %% "specs2-core" % specs2Version % "provided"
 
-// test deps
 libraryDependencies ++=
   Seq(
-    "org.scalacheck" %% "scalacheck" % "1.11.5" % "test",
+    "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
+    "org.specs2" %% "specs2-scalacheck" % specs2Version % "test",
     "org.scalaz" %% "scalaz-scalacheck-binding" % scalazVersion % "test"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,5 @@ libraryDependencies += "org.specs2" %% "specs2" % "2.4.2" % "provided"
 libraryDependencies ++=
   Seq(
     "org.scalacheck" %% "scalacheck" % "1.11.5" % "test",
-    "org.typelevel" %% "scalaz-specs2" % "0.3.0" % "test",
     "org.scalaz" %% "scalaz-scalacheck-binding" % scalazVersion % "test"
   )

--- a/src/main/scala/DefaultFormats.scala
+++ b/src/main/scala/DefaultFormats.scala
@@ -172,13 +172,13 @@ trait DefaultFormats {
         if (overallV.exists(_.isEmpty)) {
           jsFailureValidationNel("not a non-empty array")
         } else {
-          overallV.map(lst => NonEmptyList.nel(lst.head, lst.tail))
+          overallV.map(lst => NonEmptyList.nel(lst.head, IList.fromList(lst.tail)))
         }
 
       case _ => jsFailureValidationNel("not an array")
     }
 
-    def writes(as: NonEmptyList[T]) = JsArray(as.map(tw.writes).list.toSeq)
+    def writes(as: NonEmptyList[T]) = JsArray(as.map(tw.writes).list.toList)
   }
 
   private[this] def tryCatchingToJsFailureValidationNel[T, E <: Exception](msg: String, f: => T)(implicit m: Manifest[E]): JsonzValidation[T] = {

--- a/src/main/scala/specs2/Specs2JsonzTestkit.scala
+++ b/src/main/scala/specs2/Specs2JsonzTestkit.scala
@@ -43,10 +43,10 @@ trait Specs2JsonzTestkit extends MatchersImplicits {
     ((v: Validation[_,T]) => v.exists(f), (v: Validation[_,T]) => s"""$v did not match""")
 
   def containFailure[A, B](a: A): Matcher[ValidationNel[A, B]] =
-    ((v: ValidationNel[A, B]) => v.swap.map(_.list.contains(a)) getOrElse false)
+    ((v: ValidationNel[A, B]) => v.swap.map(_.list.toList.contains(a)) getOrElse false)
 
   def haveFailureCount[A, B](n: Int): Matcher[ValidationNel[A, B]] =
-    ((v: ValidationNel[A, B]) => v.swap.map(_.list.size == n) getOrElse false)
+    ((v: ValidationNel[A, B]) => v.swap.map(_.list.length == n) getOrElse false)
 
   private[this] def extract[T](js: JsValue, field: Symbol)(implicit tr: Reads[T]): Option[T] =
     js.asInstanceOf[JsObject].get(field.name).map(tr.reads).flatMap(_.toOption)

--- a/src/test/scala/DefaultFormatsSpec.scala
+++ b/src/test/scala/DefaultFormatsSpec.scala
@@ -8,9 +8,9 @@ object DefaultFormatsSpec extends JsonzSpec {
   import DefaultFormats._
   import Jsonz._
 
-  "JsValue" ! check(toAndFrom[JsValue])
+  "JsValue" ! toAndFrom[JsValue]
 
-  "Int" ! check(toAndFrom[Int])
+  "Int" ! toAndFrom[Int]
   "Int failures" ! {
     fromJson[Int](JsString("abc")) must containJsFailureStatement("not an int")
     fromJson[Int](JsNull) must containJsFailureStatement("not an int")
@@ -20,7 +20,7 @@ object DefaultFormatsSpec extends JsonzSpec {
     fromJson[Int](JsNumber(1.23)) must containJsFailureStatement("not an int")
   }
 
-  "Short" ! check(toAndFrom[Short])
+  "Short" ! toAndFrom[Short]
   "Short failures" ! {
     fromJson[Short](JsString("abc")) must containJsFailureStatement("not a short")
     fromJson[Short](JsNull) must containJsFailureStatement("not a short")
@@ -31,7 +31,7 @@ object DefaultFormatsSpec extends JsonzSpec {
     fromJson[Short](JsNumber(32768)) must containJsFailureStatement("not a short")
   }
 
-  "Long" ! check(toAndFrom[Long])
+  "Long" ! toAndFrom[Long]
   "Long failures" ! {
     fromJson[Long](JsString("abc")) must containJsFailureStatement("not a long")
     fromJson[Long](JsNull) must containJsFailureStatement("not a long")
@@ -41,7 +41,7 @@ object DefaultFormatsSpec extends JsonzSpec {
     fromJson[Long](JsNumber(1.23)) must containJsFailureStatement("not a long")
   }
 
-  "Float" ! check(toAndFrom[Float])
+  "Float" ! toAndFrom[Float]
   "Float failures" ! {
     fromJson[Float](JsString("abc")) must containJsFailureStatement("not a float")
     fromJson[Float](JsNull) must containJsFailureStatement("not a float")
@@ -50,7 +50,7 @@ object DefaultFormatsSpec extends JsonzSpec {
     fromJson[Float](JsObject(Nil)) must containJsFailureStatement("not a float")
   }
 
-  "Double" ! check(toAndFrom[Double])
+  "Double" ! toAndFrom[Double]
   "Double failures" ! {
     fromJson[Double](JsString("abc")) must containJsFailureStatement("not a double")
     fromJson[Double](JsNull) must containJsFailureStatement("not a double")
@@ -59,9 +59,9 @@ object DefaultFormatsSpec extends JsonzSpec {
     fromJson[Double](JsObject(Nil)) must containJsFailureStatement("not a double")
   }
 
-  "BigDecimal" ! pending // check(toAndFrom[BigDecimal]) // arithmetic overflows
+  "BigDecimal" ! pending // toAndFrom[BigDecimal] // arithmetic overflows
 
-  "Boolean" ! check(toAndFrom[Boolean])
+  "Boolean" ! toAndFrom[Boolean]
   "Boolean failures" ! {
     fromJson[Boolean](JsString("abc")) must containJsFailureStatement("not a boolean")
     fromJson[Boolean](JsNull) must containJsFailureStatement("not a boolean")
@@ -70,9 +70,9 @@ object DefaultFormatsSpec extends JsonzSpec {
     fromJson[Boolean](JsNumber(1.23)) must containJsFailureStatement("not a boolean")
    }
 
-  "Map[String, String]" ! check(toAndFrom[Map[String, String]])
-  "Map[String, Int]" ! check(toAndFrom[Map[String, Int]])
-  "Map[String, Map[String, Int]]" ! check(toAndFrom[Map[String, Map[String, Int]]])
+  "Map[String, String]" ! toAndFrom[Map[String, String]]
+  "Map[String, Int]" ! toAndFrom[Map[String, Int]]
+  "Map[String, Map[String, Int]]" ! toAndFrom[Map[String, Map[String, Int]]]
   "Map failures" ! {
     fromJson[Map[String, String]](JsString("abc")) must containJsFailureStatement("not an object")
     fromJson[Map[String, String]](JsNull) must containJsFailureStatement("not an object")
@@ -82,7 +82,7 @@ object DefaultFormatsSpec extends JsonzSpec {
     fromJson[Map[String, String]](JsObject(Seq("abc" -> JsNumber(123)))) must containJsFieldFailure("abc", "not a string")
   }
 
-  "String" ! check(toAndFrom[String])
+  "String" ! toAndFrom[String]
   "String failures" ! {
     fromJson[String](JsObject(Nil)) must containJsFailureStatement("not a string")
     fromJson[String](JsNull) must containJsFailureStatement("not a string")
@@ -92,11 +92,11 @@ object DefaultFormatsSpec extends JsonzSpec {
   }
 
   import scala.collection.mutable
-  "List[String]" ! check(toAndFrom[List[String]])
-  "List[Int]" ! check(toAndFrom[List[Int]])
-  "Seq[String]" ! check(toAndFrom[Seq[String]])
-  "Stream[String]" ! check(toAndFrom[Stream[String]])
-  "mutable.Set[String]" ! check(toAndFrom[mutable.Set[String]])
+  "List[String]" ! toAndFrom[List[String]]
+  "List[Int]" ! toAndFrom[List[Int]]
+  "Seq[String]" ! toAndFrom[Seq[String]]
+  "Stream[String]" ! toAndFrom[Stream[String]]
+  "mutable.Set[String]" ! toAndFrom[mutable.Set[String]]
   "Traversable failures" ! {
     fromJson[List[String]](JsObject(Nil)) must containJsFailureStatement("not an array")
     fromJson[List[String]](JsNull) must containJsFailureStatement("not an array")
@@ -108,8 +108,8 @@ object DefaultFormatsSpec extends JsonzSpec {
     fromJson[mutable.Set[String]](JsArray(Seq(JsNumber(1.23), JsBoolean(false)))) must containJsFailureStatement("not a string")
   }
 
-  "Array[String]" ! check(transformFirst[Array[String], JsArray](items => JsArray(items.map(toJson(_)))))
-  "Array[Int]" ! check(transformFirst[Array[Int], JsArray](items => JsArray(items.map(toJson(_)))))
+  "Array[String]" ! transformFirst[Array[String], JsArray](items => JsArray(items.map(toJson(_))))
+  "Array[Int]" ! transformFirst[Array[Int], JsArray](items => JsArray(items.map(toJson(_))))
   "Array failures" ! {
     fromJson[Array[String]](JsObject(Nil)) must containJsFailureStatement("not an array")
     fromJson[Array[String]](JsNull) must containJsFailureStatement("not an array")
@@ -119,14 +119,14 @@ object DefaultFormatsSpec extends JsonzSpec {
     fromJson[Array[String]](JsArray(Seq(JsBoolean(false)))) must containJsFailureStatement("not a string")
   }
 
-  "Option[Int]" ! check(toAndFrom[Option[Int]])
-  "Option[String]" ! check(toAndFrom[Option[String]])
-  "Option[Map[String, List[Int]]]" ! check(toAndFrom[Option[Map[String, List[Int]]]])
+  "Option[Int]" ! toAndFrom[Option[Int]]
+  "Option[String]" ! toAndFrom[Option[String]]
+  "Option[Map[String, List[Int]]]" ! toAndFrom[Option[Map[String, List[Int]]]]
   "Option failures" ! {
     fromJson[Option[Int]](JsString("abc")) must containJsFailureStatement("not an int")
   }
 
-  "NonEmptyList[Int]" ! check(toAndFrom[NonEmptyList[Int]])
+  "NonEmptyList[Int]" ! toAndFrom[NonEmptyList[Int]]
   "NonEmptyList failures" ! {
     fromJson[NonEmptyList[String]](JsObject(Nil)) must containJsFailureStatement("not an array")
     fromJson[NonEmptyList[String]](JsNull) must containJsFailureStatement("not an array")
@@ -137,10 +137,10 @@ object DefaultFormatsSpec extends JsonzSpec {
     fromJson[NonEmptyList[String]](JsArray(Nil)) must containJsFailureStatement("not a non-empty array")
   }
 
-  "NonEmptyList[JsFailure]" ! check(toAndFrom[NonEmptyList[JsFailure]])
+  "NonEmptyList[JsFailure]" ! toAndFrom[NonEmptyList[JsFailure]]
 
-  "Left[Int, _]" ! check(toAndFrom[({ type l[a] = Left[a, String] })#l, Int](Left.apply))
-  "Right[_, Int]" ! check(toAndFrom[({ type r[a] = Right[String, a] })#r, Int](Right.apply))
+  "Left[Int, _]" ! toAndFrom[({ type l[a] = Left[a, String] })#l, Int](Left.apply)
+  "Right[_, Int]" ! toAndFrom[({ type r[a] = Right[String, a] })#r, Int](Right.apply)
 
   "Left's and Right's should combine powers" ! {
     val model1: Either[Int, String] = Left(100)

--- a/src/test/scala/JsonzSpec.scala
+++ b/src/test/scala/JsonzSpec.scala
@@ -13,7 +13,7 @@ trait JsonzSpec extends Specification with ScalaCheck with MatchersImplicits wit
     props.properties.foreach {
       case (name2, prop) =>
         name in {
-          name2 ! check(prop)
+          name2 ! prop
         }
     }
 

--- a/src/test/scala/ReadWriteJsonSpec.scala
+++ b/src/test/scala/ReadWriteJsonSpec.scala
@@ -3,7 +3,7 @@ import jsonz.models._
 import scalaz._
 
 object ReadWriteJsonSpec extends JsonzSpec {
-  "can write a person" in check { (person: Person) =>
+  "can write a person" in prop { (person: Person) =>
     val js = Jsonz.toJson(person)
     val middleJson = person.name.middle.map(JsString.apply).getOrElse(JsNull)
     js must beLike {

--- a/src/test/scala/SerializationSpec.scala
+++ b/src/test/scala/SerializationSpec.scala
@@ -8,7 +8,7 @@ object SerializationSpec extends JsonzSpec {
   import jsonz._
   import jsonz.DefaultFormats._
 
-  "Writes arbitrary JsValue's to and from strings" ! check { js: JsValue =>
+  "Writes arbitrary JsValue's to and from strings" ! prop { js: JsValue =>
     val wrote = Jsonz.toJsonStr(js)
     val read = Jsonz.fromJsonStr[JsValue](wrote)
     read must beSuccessful(js)
@@ -34,13 +34,13 @@ object SerializationSpec extends JsonzSpec {
     Jsonz.fromJsonStr[String]("not valid json") must containFailure(JsFailureStatement("not valid JSON"))
   }
 
-  "to/from bytes" ! check { js: JsValue =>
+  "to/from bytes" ! prop { js: JsValue =>
     val wrote: Array[Byte] = Jsonz.toJsonBytes(js)
     val read = Jsonz.fromJsonBytes[JsValue](wrote)
     read must beSuccessful(js)
   }
 
-  "to/from Input/Output streams" ! check { js: JsValue =>
+  "to/from Input/Output streams" ! prop { js: JsValue =>
     import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
     val out = new ByteArrayOutputStream

--- a/src/test/scala/ValidationFormatsSpec.scala
+++ b/src/test/scala/ValidationFormatsSpec.scala
@@ -10,11 +10,11 @@ object ValidationFormatsSpec extends JsonzSpec with ValidationFormats {
 
   type JsonzFailure[E] = Validation[E, JsValue]
 
-  "write out a Success" ! check(toAndFrom[({ type l[a] = JsonzValidation[a] })#l, Int](Success.apply(_): Validation[Nothing, Int]))
+  "write out a Success" ! toAndFrom[({ type l[a] = JsonzValidation[a] })#l, Int](Success.apply(_): Validation[Nothing, Int])
 
-  "write out failures" ! check(toAndFrom[({ type l[a] = JsonzFailure[a] })#l, Int](Failure.apply(_): Validation[Int, Nothing]))
+  "write out failures" ! toAndFrom[({ type l[a] = JsonzFailure[a] })#l, Int](Failure.apply(_): Validation[Int, Nothing])
 
-  "write out failure nel's" ! check(toAndFrom[({ type l[a] = JsonzFailure[a]})#l, NonEmptyList[Int]](n => Failure.apply(n): ValidationNel[Int, Nothing]))
+  "write out failure nel's" ! toAndFrom[({ type l[a] = JsonzFailure[a]})#l, NonEmptyList[Int]](n => Failure.apply(n): ValidationNel[Int, Nothing])
 
   def toAndFrom[M[_], T: Reads : Writes : Arbitrary](builder: T => M[T])(implicit mw: Writes[M[T]]) = Prop.forAll { (o: T) =>
     val wrote = toJson(builder(o))

--- a/src/test/scala/joda/JodaTimeFormatsSpec.scala
+++ b/src/test/scala/joda/JodaTimeFormatsSpec.scala
@@ -12,21 +12,22 @@ object JodaTimeFormatsSpec extends JsonzSpec with ScalaCheck with JodaTimeFormat
 
   implicit val arbitraryDate: Arbitrary[DateTime] = Arbitrary {
     for {
-      d <- Arbitrary.arbitrary[Date] if d.getYear >= 0 && d.getYear <= 9999
-    } yield new DateTime(d, DateTimeZone.UTC)
+      d <- Arbitrary.arbitrary[Date]
+      year <- Gen.choose(0, 9999)
+    } yield (new DateTime(d, DateTimeZone.UTC)).withYear(year)
   }
 
   "DateTimeFormat" should {
     "read from ISO8601 format" in {
-      check(toAndFrom[DateTime])
+      toAndFrom[DateTime]
     }
 
     "read from YYYY-MM-dd format" in {
-      check(transformFirst[DateTime, JsString](dt => JsString(dt.toString("YYYY-MM-dd"))))
+      transformFirst[DateTime, JsString](dt => JsString(dt.toString("YYYY-MM-dd")))
     }
 
     "read from long format" in {
-      check(transformFirst[DateTime, JsNumber](dt => JsNumber(dt.getMillis)))
+      transformFirst[DateTime, JsNumber](dt => JsNumber(dt.getMillis))
     }
   }
 

--- a/src/test/scala/models.scala
+++ b/src/test/scala/models.scala
@@ -89,7 +89,7 @@ package object models {
       for {
         head <- Arbitrary.arbitrary[A]
         tail <- Gen.listOfN(size, arbitrary[A])
-      } yield NonEmptyList.nel(head, tail)
+      } yield NonEmptyList.nel(head, IList.fromList(tail))
     }
   }
 
@@ -135,7 +135,7 @@ package object models {
       field <- arbitrary[String]
       n  <- Gen.choose(1, 4)
       failures <- Gen.listOfN(n, arbitrary[JsFailure])
-    } yield JsFieldFailure(field, NonEmptyList.nel(failures.head, failures.tail))
+    } yield JsFieldFailure(field, NonEmptyList.nel(failures.head, IList.fromList(failures.tail)))
 
     Gen.frequency(
       (4, genJsFailureStatement),

--- a/src/test/scala/org/specs2/scalaz/ValidationMatchers.scala
+++ b/src/test/scala/org/specs2/scalaz/ValidationMatchers.scala
@@ -1,0 +1,122 @@
+package org.specs2.scalaz
+
+import scalaz.{ Failure => ZFailure, Success => ZSuccess, Validation }
+
+import org.specs2.matcher._
+import org.specs2.text.Quote._
+import org.specs2.execute.{ Failure, Result }
+
+trait ValidationMatchers { outer =>
+
+  def beSuccessful[T](t: => T) =
+    new Matcher[Validation[_, T]] {
+      def apply[S <: Validation[_, T]](value: Expectable[S]) = {
+        val expected = t
+        result(
+          value.value == ZSuccess(t),
+          value.description + " is Success with value" + q(expected),
+          value.description + " is not Success with value" + q(expected),
+          value
+        )
+      }
+    }
+
+  def beSuccessful[T] = new SuccessValidationMatcher[T]
+
+  class SuccessValidationMatcher[T] extends Matcher[Validation[_, T]] {
+    def apply[S <: Validation[_, T]](value: Expectable[S]) = {
+      result(
+        value.value.isSuccess,
+        value.description + " is Success",
+        value.description + " is not Success",
+        value
+      )
+    }
+
+    def like(f: PartialFunction[T, MatchResult[_]]) = this and partialMatcher(f)
+
+    private def partialMatcher(f: PartialFunction[T, MatchResult[_]]) = new Matcher[Validation[_, T]] {
+      def apply[S <: Validation[_, T]](value: Expectable[S]) = {
+        val res: Result = value.value match {
+          case ZSuccess(t) if f.isDefinedAt(t)  => f(t).toResult
+          case ZSuccess(t) if !f.isDefinedAt(t) => Failure("function undefined")
+          case other                            => Failure("no match")
+        }
+        result(
+          res.isSuccess,
+          value.description + " is Success[T] and " + res.message,
+          value.description + " is Success[T] but " + res.message,
+          value
+        )
+      }
+    }
+  }
+
+  def successful[T](t: => T) = beSuccessful(t)
+  def successful[T] = beSuccessful
+
+  def beFailing[T](t: => T) = new Matcher[Validation[T, _]] {
+    def apply[S <: Validation[T, _]](value: Expectable[S]) = {
+      val expected = t
+      result(
+        value.value == ZFailure(t),
+        value.description + " is Failure with value" + q(expected),
+        value.description + " is not Failure with value" + q(expected),
+        value
+      )
+    }
+  }
+
+  def beFailing[T] = new FailureMatcher[T]
+  class FailureMatcher[T] extends Matcher[Validation[T, _]] {
+    def apply[S <: Validation[T, _]](value: Expectable[S]) = {
+      result(
+        value.value.isFailure,
+        value.description + " is Failure",
+        value.description + " is not Failure",
+        value
+      )
+    }
+
+    def like(f: PartialFunction[T, MatchResult[_]]) = this and partialMatcher(f)
+
+    private def partialMatcher(f: PartialFunction[T, MatchResult[_]]) = new Matcher[Validation[T, _]] {
+      def apply[S <: Validation[T, _]](value: Expectable[S]) = {
+        val res: Result = value.value match {
+          case ZFailure(t) if f.isDefinedAt(t)  => f(t).toResult
+          case ZFailure(t) if !f.isDefinedAt(t) => Failure("function undefined")
+          case other                            => Failure("no match")
+        }
+        result(
+          res.isSuccess,
+          value.description + " is Failure[T] and " + res.message,
+          value.description + " is Failure[T] but " + res.message,
+          value
+        )
+      }
+    }
+  }
+
+  def failing[T](t: => T) = beFailing(t)
+  def failing[T] = beFailing
+
+  import scala.language.implicitConversions
+  implicit def toValidationResultMatcher[F, S](result: MatchResult[Validation[F, S]]) =
+    new ValidationResultMatcher(result)
+
+  class ValidationResultMatcher[F, S](result: MatchResult[Validation[F, S]]) {
+    def failing(f: => F) = result(outer beFailing f)
+    def beFailing(f: => F) = result(outer beFailing f)
+    def successful(s: => S) = result(outer beSuccessful s)
+    def beSuccessful(s: => S) = result(outer beSuccessful s)
+
+    def failing = result(outer.beFailing)
+    def beFailing = result(outer.beFailing)
+    def successful = result(outer.beSuccessful)
+    def beSuccessful = result(outer.beSuccessful)
+  }
+}
+
+object ValidationMatchers extends ValidationMatchers
+
+// vim: expandtab:ts=2:sw=2

--- a/src/test/scala/spray/SpraySpec.scala
+++ b/src/test/scala/spray/SpraySpec.scala
@@ -9,7 +9,7 @@ object SpraySpec extends JsonzSpec {
   import DefaultFormats._
 
   "marshaller" should {
-    "provide for anything that has a Writes[T]" in check { jsv: JsValue =>
+    "provide for anything that has a Writes[T]" in prop { jsv: JsValue =>
       marshal(jsv) must beRight(
         HttpEntity(ContentTypes.`application/json`, Jsonz.toJsonBytes(jsv))
       )
@@ -17,7 +17,7 @@ object SpraySpec extends JsonzSpec {
   }
 
   "unmarshaller" should {
-    "provide for anything that has a Reads[T]" in check { jsv: JsValue =>
+    "provide for anything that has a Reads[T]" in prop { jsv: JsValue =>
       val body = HttpEntity(ContentTypes.`application/json`, Jsonz.toJsonBytes(jsv))
       body.as[JsValue] must beRight(jsv)
     }


### PR DESCRIPTION
This upgrades us to scalaz 7.2.5 and specs2 to 3.8.4. I did have to copy `ValidationMatchers` from [scalaz-specs2](https://github.com/typelevel/scalaz-specs2/blob/master/src/main/scala/ValidationMatchers.scala) as that was leading to dependency hell as it hasn't been released in a very long time

Closes #34 