### PR TITLE
Add deprecation notice to README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-Depracation Notice: jsonz is deprecated and no longer supported. Instead, it is recommended to use [!circe](https://github.com/circe/circe) for json processing.
+Depracation Notice: jsonz is deprecated and no longer supported. Instead, it is recommended to use [circe](https://github.com/circe/circe) for json processing.
 
 # jsonz
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-Depracation Notice: jsonz is deprecated and no longer supported. Instead, it is recommended to use [circe](https://github.com/circe/circe) for json processing.
+Deprecation Notice: jsonz is deprecated and no longer supported. Instead, it is recommended to use [circe](https://github.com/circe/circe) for json processing.
 
 # jsonz
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,5 @@
+Depracation Notice: jsonz is deprecated and no longer supported. Instead, it is recommended to use [!circe](https://github.com/circe/circe) for json processing.
+
 # jsonz
 
 [ ![Download](https://api.bintray.com/packages/banno/oss/jsonz/images/download.svg) ](https://bintray.com/banno/oss/jsonz/_latestVersion)


### PR DESCRIPTION
Adds a deprecation notice to the readme, suggesting circe as an alternative.